### PR TITLE
Add submodule setup automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This project provides a complete VS Code configuration for GitHub Copilot Chat t
    - VS Code 1.99+
    - GitHub Copilot Chat extension installed and configured
    - Git repository initialized
+   - Clone with submodules: `git clone --recurse-submodules <repo-url>`
+   - Or run `./scripts/init-submodules.sh` after cloning
 
 2. **Copy Configuration Files**:
    ```bash

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -16,12 +16,15 @@
 
 1. Initialize and configure OpenAI SDK integration
 2. Document SDK usage patterns and requirements
-3. Update development setup instructions for submodule handling
+3. Verify submodule automation script across environments
 4. Consider additional dependencies that may be needed
 
 ## Recent Changes
 
 **Files Created/Modified:**
+- `scripts/init-submodules.sh` - Added automation for git submodule setup
+- `scripts/README.md` - Documented new script
+- `README.md` - Added cloning instructions for submodules
 
 - `vendors/openai-sdk` - Added OpenAI Node.js SDK as git submodule
 - `memory-bank/techContext.md` - Updated with OpenAI SDK integration details

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -24,6 +24,7 @@
 - Dependency management structure using `vendors` directory
 - Documentation of external dependencies in Memory Bank system
 - Git submodule workflow established for third-party code management
+- Submodule setup automated via `scripts/init-submodules.sh` and documented in README
 
 **Validated Approaches:**
 

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -41,6 +41,9 @@
 # [TO BE DEFINED - Step-by-step setup commands]
 # 1. Install prerequisites
 # 2. Clone and configure
+git clone --recurse-submodules <repo-url>
+cd <repo-dir>
+./scripts/init-submodules.sh
 # 3. Install dependencies
 # 4. Run development server
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -209,6 +209,12 @@ working directory. This helps validate the runtime context during each
 lifecycle phase and is useful for troubleshooting or for CI/CD pipelines
 that need to capture environment metadata.
 
+### init-submodules.sh
+
+`init-submodules.sh` initializes and updates git submodules automatically.
+It runs `git submodule update --init --recursive` to ensure all dependencies are fetched.
+
+
 ---
 
 ## Adding New Scripts

--- a/scripts/init-submodules.sh
+++ b/scripts/init-submodules.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# init-submodules.sh - Initialize and update all git submodules
+
+set -euo pipefail
+
+# Show help if requested
+if [[ ${1:-} == "--help" ]]; then
+  echo "Usage: ./scripts/init-submodules.sh"
+  echo "Initializes and updates all git submodules recursively."
+  exit 0
+fi
+
+# Initialize and update submodules
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  git submodule update --init --recursive
+  echo "Git submodules initialized and updated." 
+else
+  echo "Error: not inside a git repository" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add `init-submodules.sh` for easy submodule initialization
- document the new script in `scripts/README.md`
- mention cloning with `--recurse-submodules` in project README
- include setup commands in `techContext.md`
- record updates in `activeContext.md` and `progress.md`

## Testing
- `npm install`
- `node scripts/validate-config.js` *(fails: Missing required settings)*

------
https://chatgpt.com/codex/tasks/task_e_68439dc8e3ec8331b97fe35671d17a70